### PR TITLE
fix liquid compile errors

### DIFF
--- a/CurdsLiquid.cs
+++ b/CurdsLiquid.cs
@@ -75,7 +75,7 @@ namespace XRL.Liquids
 			return true;
 		}
 
-		public override void RenderBackground(LiquidVolume Liquid, RenderEvent eRender)
+		public override void RenderBackgroundPrimary(LiquidVolume Liquid, RenderEvent eRender)
 		{
 			eRender.ColorString = "^Y" + eRender.ColorString;
 		}
@@ -126,18 +126,14 @@ namespace XRL.Liquids
 			eRender.ColorString += "&Y";
 		}
 
-		public override void RenderSmearPrimary(LiquidVolume Liquid, RenderEvent eRender)
+		public override void RenderSmearPrimary(LiquidVolume Liquid, RenderEvent eRender, GameObject obj)
 		{
 			int num = XRLCore.CurrentFrame % 60;
 			if (num > 5 && num < 15)
 			{
 				eRender.ColorString = "&Y";
 			}
-			base.RenderSmearPrimary(Liquid, eRender);
-		}
-
-		public override void ObjectEnteredCell(LiquidVolume Liquid, GameObject GO)
-		{
+			base.RenderSmearPrimary(Liquid, eRender, obj);
 		}
 
 		public override float GetValuePerDram()

--- a/MilkLiquid.cs
+++ b/MilkLiquid.cs
@@ -76,7 +76,7 @@ namespace XRL.Liquids
 			return true;
 		}
 
-		public override void RenderBackground(LiquidVolume Liquid, RenderEvent eRender)
+		public override void RenderBackgroundPrimary(LiquidVolume Liquid, RenderEvent eRender)
 		{
 			eRender.ColorString = "^Y" + eRender.ColorString;
 		}
@@ -127,18 +127,14 @@ namespace XRL.Liquids
 			eRender.ColorString += "&Y";
 		}
 
-		public override void RenderSmearPrimary(LiquidVolume Liquid, RenderEvent eRender)
+		public override void RenderSmearPrimary(LiquidVolume Liquid, RenderEvent eRender, GameObject obj)
 		{
 			int num = XRLCore.CurrentFrame % 60;
 			if (num > 5 && num < 15)
 			{
 				eRender.ColorString = "&Y";
 			}
-			base.RenderSmearPrimary(Liquid, eRender);
-		}
-
-		public override void ObjectEnteredCell(LiquidVolume Liquid, GameObject GO)
-		{
+			base.RenderSmearPrimary(Liquid, eRender, obj);
 		}
 
 		public override float GetValuePerDram()

--- a/YoghurtLiquid.cs
+++ b/YoghurtLiquid.cs
@@ -75,7 +75,7 @@ namespace XRL.Liquids
 			return true;
 		}
 
-		public override void RenderBackground(LiquidVolume Liquid, RenderEvent eRender)
+		public override void RenderBackgroundPrimary(LiquidVolume Liquid, RenderEvent eRender)
 		{
 			eRender.ColorString = "^Y" + eRender.ColorString;
 		}
@@ -126,18 +126,14 @@ namespace XRL.Liquids
 			eRender.ColorString += "&Y";
 		}
 
-		public override void RenderSmearPrimary(LiquidVolume Liquid, RenderEvent eRender)
+		public override void RenderSmearPrimary(LiquidVolume Liquid, RenderEvent eRender, GameObject obj)
 		{
 			int num = XRLCore.CurrentFrame % 60;
 			if (num > 5 && num < 15)
 			{
 				eRender.ColorString = "&Y";
 			}
-			base.RenderSmearPrimary(Liquid, eRender);
-		}
-
-		public override void ObjectEnteredCell(LiquidVolume Liquid, GameObject GO)
-		{
+			base.RenderSmearPrimary(Liquid, eRender, obj);
 		}
 
 		public override float GetValuePerDram()


### PR DESCRIPTION
this pr contains the bare minimum changes required to address #3. it does not address other bugs, such as `milkLichen` spawning with green milk, and it fixes warnings only in files that had errors. i wasn't sure how `RenderBackgroundPrimary` and `RenderBackgroundSecondary` relate to the old `RenderBackground` method, so i picked one arbitrarily to replace it