### PR TITLE
Add mutation leveling and fix warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore files built by dotnet build
+bin/**
+obj/**
+# Ignore (symlinked) dll files
+*.dll

--- a/ChanceToMutate.cs
+++ b/ChanceToMutate.cs
@@ -12,30 +12,30 @@ namespace XRL.World.Parts
 	[Serializable]
 	public class acegiak_ChanceToMutate  : IPart
 	{
-        public string Mutation = "Milk Glands";
-        public int Chance = 95;
-        public int Level = 1;
+		public string Mutation = "Milk Glands";
+		public int Chance = 95;
+		public int Level = 1;
 
-        public void domutate(){
-            if(ParentObject.IsPlayer() || ParentObject.IsMemberOfFaction("Templar")){
-                return;
-            }
-            int roll = Stat.Random(1,100);
-           Log("Titroll:"+roll.ToString()+"/"+Chance.ToString());
-            if(roll<=Chance){
-                Mutations mutations = ParentObject.GetPart("Mutations") as Mutations;
-                if (mutations == null )
-                {
-                   Log("Can mutate, no mutations part");
-                    return ;
-                }
-                if( ! MutationFactory.MutationsByName.ContainsKey(Mutation)){
-                   Log("Mutation "+Mutation+" isn't recognised");
-                }
-                mutations.AddMutation(MutationFactory.MutationsByName[Mutation].CreateInstance(), Level);
-               Log("mutated");
-            }
-        }
+		public void domutate(){
+			if(ParentObject.IsPlayer() || ParentObject.IsMemberOfFaction("Templar")){
+				return;
+			}
+			int roll = Stat.Random(1,100);
+			Log("Titroll:"+roll.ToString()+"/"+Chance.ToString());
+			if(roll<=Chance){
+				Mutations mutations = ParentObject.GetPart("Mutations") as Mutations;
+				if (mutations == null )
+				{
+					Log("Can mutate, no mutations part");
+					return ;
+				}
+				if(!MutationFactory.HasMutation(Mutation)){
+					Log("Mutation "+Mutation+" isn't recognised");
+				}
+				mutations.AddMutation(MutationFactory.GetMutationEntryByName(Mutation).CreateInstance(), Level);
+				Log("mutated");
+			}
+		}
 
 		public override void Register(GameObject Object)
 		{
@@ -47,10 +47,10 @@ namespace XRL.World.Parts
 		{
 			if (E.ID == "ObjectCreated")
 			{
-                domutate();
-            }
-            return base.FireEvent(E);
-        }
-    }
+				domutate();
+			}
+			return base.FireEvent(E);
+		}
+	}
 
 }

--- a/CurdsLiquid.cs
+++ b/CurdsLiquid.cs
@@ -75,7 +75,7 @@ namespace XRL.Liquids
 			return true;
 		}
 
-		public override void RenderBackground(LiquidVolume Liquid, RenderEvent eRender)
+		public override void RenderBackgroundPrimary(LiquidVolume Liquid, RenderEvent eRender)
 		{
 			eRender.ColorString = "^Y" + eRender.ColorString;
 		}
@@ -126,18 +126,14 @@ namespace XRL.Liquids
 			eRender.ColorString += "&Y";
 		}
 
-		public override void RenderSmearPrimary(LiquidVolume Liquid, RenderEvent eRender)
+		public override void RenderSmearPrimary(LiquidVolume Liquid, RenderEvent eRender, GameObject obj)
 		{
 			int num = XRLCore.CurrentFrame % 60;
 			if (num > 5 && num < 15)
 			{
 				eRender.ColorString = "&Y";
 			}
-			base.RenderSmearPrimary(Liquid, eRender);
-		}
-
-		public override void ObjectEnteredCell(LiquidVolume Liquid, GameObject GO)
-		{
+			base.RenderSmearPrimary(Liquid, eRender, obj);
 		}
 
 		public override float GetValuePerDram()

--- a/GlandPart.cs
+++ b/GlandPart.cs
@@ -27,7 +27,7 @@ namespace XRL.World.Parts.Mutation
 		}
 		public static int GetProductionRate(int Level)
 		{
-			return (int) (1000.0d * Math.Pow(0.9, Level-1));
+			return (int) (500.0d * Math.Pow(0.9, Level-1));
 		} 
 		public int GetProductionRate()
 		{

--- a/GlandPart.cs
+++ b/GlandPart.cs
@@ -27,7 +27,7 @@ namespace XRL.World.Parts.Mutation
 		}
 		public static int GetProductionRate(int Level)
 		{
-			return 1000 * (int) Math.Pow(0.9, Level-1);
+			return (int) (1000.0d * Math.Pow(0.9, Level-1));
 		} 
 		public int GetProductionRate()
 		{

--- a/GlandPart.cs
+++ b/GlandPart.cs
@@ -6,20 +6,14 @@ namespace XRL.World.Parts.Mutation
 	[Serializable]
 	public class acegiak_Glands  : BaseMutation
 	{
-		public int Bonus;
-
-		public int FeetID;
-
-		public int OldFeetID;
-
-        public string GlandType = "milk";
+		public string GlandType = "milk";
 
 		public acegiak_Glands()
 		{
 			DisplayName = "Milk Glands";
 			Type = "Physical";
 		}
-        public override bool SameAs(IPart p)
+		public override bool SameAs(IPart p)
 		{
 			return false;
 		}
@@ -54,7 +48,7 @@ namespace XRL.World.Parts.Mutation
 			GlandsObject.GetPart<LiquidProducer>().Rate = GetProductionRate();
 			GlandsObject.GetPart<LiquidVolume>().MaxVolume = GetMaxVolume();
 		}
-        public void AddBodyPart(){
+		public void AddBodyPart(){
 
 			string gtype = ParentObject.GetTag("GlandLiquid");
 			if(gtype != null){
@@ -62,7 +56,7 @@ namespace XRL.World.Parts.Mutation
 				this.GlandType = gtype;
 			}
 
-            Body part = ParentObject.GetPart<Body>();
+			Body part = ParentObject.GetPart<Body>();
 			if (part != null)
 			{
 				BodyPart body = part.GetBody();
@@ -72,7 +66,7 @@ namespace XRL.World.Parts.Mutation
 				}
 
 				BodyPart firstPart = body.AddPart(new BodyPart("Glands",part),"Back");
-                GameObject GlandsObject = GameObjectFactory.Factory.CreateObject("DefaultGlands");
+				GameObject GlandsObject = GameObjectFactory.Factory.CreateObject("DefaultGlands");
 				GlandsObject.DisplayName = GlandType+" glands";
 				SyncStats();
 				GlandsObject.GetPart<LiquidProducer>().Liquid=GlandType;
@@ -88,10 +82,10 @@ namespace XRL.World.Parts.Mutation
 				@event.SetSilent(true);
 				ParentObject.FireEvent(@event);
 
-            }
+			}
 
 
-        }
+		}
 
 		public override void Register(GameObject Object)
 		{
@@ -99,13 +93,11 @@ namespace XRL.World.Parts.Mutation
 			Object.RegisterPartEvent(this, "GetInventoryActions");
 			Object.RegisterPartEvent(this, "InvCommandMilk");
 			Object.RegisterPartEvent(this, "GetShortDescription");
-            base.Register(Object);
+			base.Register(Object);
 		}
 
 		public GameObject GetGlands()
 		{
-			GameObject result = null;
-			int num = 0;
 			Body part = ParentObject.GetPart<Body>();
 			BodyPart bp = part.GetFirstPart("Glands");
 
@@ -113,21 +105,21 @@ namespace XRL.World.Parts.Mutation
 		}
 		public override bool FireEvent(Event E)
 		{
-            if(E.ID =="ObjectCreated"){
-                AddBodyPart();
-            }
-
-
-            if (E.ID == "GetInventoryActions")
-			{
-                //if(Volume > 0){
-						// E.AddInventoryAction("Drink", 'k',  false, "drin&Wk&y", "InvCommandDrinkObject");
-						E.AddInventoryAction("Milk", 'm',  false, "&Wm&yilk", "InvCommandMilk");
-                        // E.AddInventoryAction("Collect", 'c',  false, "&Wc&yollect", "InvCommandCollectObject");
-                //}
+			if(E.ID =="ObjectCreated"){
+				AddBodyPart();
 			}
 
-            if (E.ID == "InvCommandMilk")
+
+			if (E.ID == "GetInventoryActions")
+			{
+				//if(Volume > 0){
+						// E.AddInventoryAction("Drink", 'k',  false, "drin&Wk&y", "InvCommandDrinkObject");
+						E.AddInventoryAction("Milk", 'm',  false, "&Wm&yilk", "InvCommandMilk");
+						// E.AddInventoryAction("Collect", 'c',  false, "&Wc&yollect", "InvCommandCollectObject");
+				//}
+			}
+
+			if (E.ID == "InvCommandMilk")
 			{
 				GameObject GO = GetGlands();
 				if(GO != null)
@@ -153,7 +145,6 @@ namespace XRL.World.Parts.Mutation
 						}
 					}
 					GO.FireEvent(E.Copy("InvCommandPourObject"));
-
 				}
 			}
 
@@ -187,7 +178,6 @@ namespace XRL.World.Parts.Mutation
 			return base.ChangeLevel(NewLevel);
 		}
 
-
 		public override bool Mutate(GameObject GO, int Level)
 		{
 			Unmutate(GO);
@@ -197,10 +187,10 @@ namespace XRL.World.Parts.Mutation
 				BodyPart body = part.GetBody();
 
 				int glandcount = body.GetPartCount("Glands");
-                if(glandcount <= 0){
-                    AddBodyPart();
-                }
-            }
+				if(glandcount <= 0){
+					AddBodyPart();
+				}
+			}
 			return base.Mutate(GO, Level);
 		}
 
@@ -212,10 +202,10 @@ namespace XRL.World.Parts.Mutation
 				BodyPart body = part.GetBody();
 
 				int glandcount = body.GetPartCount("Glands");
-                if(glandcount > 0){
-                    body.RemovePart(body.GetFirstPart("Glands"));
-                }
-            }
+				if(glandcount > 0){
+					body.RemovePart(body.GetFirstPart("Glands"));
+				}
+			}
 			return base.Unmutate(GO);
 		}
 	}

--- a/GlandPart.cs
+++ b/GlandPart.cs
@@ -17,13 +17,9 @@ namespace XRL.World.Parts.Mutation
 		{
 			return false;
 		}
-		public override bool CanLevel()
-		{
-			return false;
-		}
 		public static int GetMaxVolume(int Level)
 		{
-			return 8 + Level * 2;
+			return 6 + Level * 2;
 		}
 		public int GetMaxVolume()
 		{
@@ -31,7 +27,7 @@ namespace XRL.World.Parts.Mutation
 		}
 		public static int GetProductionRate(int Level)
 		{
-			return 1000 * (int) Math.Pow(0.9, Level);
+			return 1000 * (int) Math.Pow(0.9, Level-1);
 		} 
 		public int GetProductionRate()
 		{
@@ -69,11 +65,13 @@ namespace XRL.World.Parts.Mutation
 				GameObject GlandsObject = GameObjectFactory.Factory.CreateObject("DefaultGlands");
 				GlandsObject.DisplayName = GlandType+" glands";
 				SyncStats();
-				GlandsObject.GetPart<LiquidProducer>().Liquid=GlandType;
-				GlandsObject.GetPart<LiquidVolume>().Empty();
-				GlandsObject.GetPart<LiquidVolume>().InitialLiquid=GlandType+"-"+GetMaxVolume();
-				GlandsObject.GetPart<LiquidVolume>().Volume = GlandsObject.GetPart<LiquidVolume>().StartVolume.RollCached();
-				//GlandsObject.GetPart<acegiak_NoPour>().ProcessInitialLiquid(GlandType-"1000");
+				LiquidProducer liquidProducer = GlandsObject.GetPart<LiquidProducer>();
+				LiquidVolume liquidVolume = GlandsObject.GetPart<LiquidVolume>();
+				liquidProducer.Liquid=GlandType;
+				liquidVolume.Empty();
+				liquidVolume.StartVolume = "1-"+liquidVolume.MaxVolume;
+				liquidVolume.InitialLiquid = GlandType;
+				liquidVolume.Volume = liquidVolume.StartVolume.RollCached();
 
 
 				Event @event = Event.New("CommandForceEquipObject");

--- a/MilkLiquid.cs
+++ b/MilkLiquid.cs
@@ -76,7 +76,7 @@ namespace XRL.Liquids
 			return true;
 		}
 
-		public override void RenderBackground(LiquidVolume Liquid, RenderEvent eRender)
+		public override void RenderBackgroundPrimary(LiquidVolume Liquid, RenderEvent eRender)
 		{
 			eRender.ColorString = "^Y" + eRender.ColorString;
 		}
@@ -127,18 +127,14 @@ namespace XRL.Liquids
 			eRender.ColorString += "&Y";
 		}
 
-		public override void RenderSmearPrimary(LiquidVolume Liquid, RenderEvent eRender)
+		public override void RenderSmearPrimary(LiquidVolume Liquid, RenderEvent eRender, GameObject obj)
 		{
 			int num = XRLCore.CurrentFrame % 60;
 			if (num > 5 && num < 15)
 			{
 				eRender.ColorString = "&Y";
 			}
-			base.RenderSmearPrimary(Liquid, eRender);
-		}
-
-		public override void ObjectEnteredCell(LiquidVolume Liquid, GameObject GO)
-		{
+			base.RenderSmearPrimary(Liquid, eRender, obj);
 		}
 
 		public override float GetValuePerDram()

--- a/ObjectBlueprints.xml
+++ b/ObjectBlueprints.xml
@@ -64,14 +64,14 @@
       </object>
       
         <object Name="milkLichen" Inherits="LiquidLichen">
-                <part Name="Render" RenderIfDark="true" DisplayName="&amp;ygiant &amp;wmilk&amp;y weep" RenderString="231" ColorString="&amp;w"></part>
+                <part Name="Render" RenderIfDark="true" DisplayName="giant {{Y|milk}} weep" RenderString="231" ColorString="&amp;Y"></part>
                 <mutation Name="LiquidFont" Liquid="milk"></mutation>
-                <part Name="SecretObject" text="A &amp;ygiant &amp;wmilk&amp;y weep" message="You spot a &amp;ygiant &amp;wmilk&amp;y weep." adjectives="milk,weep" category="Natural Features"></part>
+                <part Name="SecretObject" text="A giant {{Y|milk}} weep" message="You spot a giant {{Y|milk}} weep." adjectives="milk,weep" category="Natural Features"></part>
         </object>
         <object Name="milkLichen Minor" Inherits="LiquidLichen Minor">
-                <part Name="Render" RenderIfDark="true" DisplayName="&amp;wmilk&amp;y weep" RenderString="231" ColorString="&amp;w"></part>
+                <part Name="Render" RenderIfDark="true" DisplayName="{{Y|milk}} weep" RenderString="231" ColorString="&amp;Y"></part>
                 <mutation Name="LiquidFont" Liquid="milk"></mutation>
-                <part Name="SecretObject" text="A &amp;wmilk&amp;y weep" message="You spot a &amp;wmilk&amp;y weep." adjectives="milk,weep" category="Natural Features"></part>
+                <part Name="SecretObject" text="A {{Y|milk}} weep" message="You spot a {{Y|milk}} weep." adjectives="milk,weep" category="Natural Features"></part>
         </object>
       <!-- <object Name="YoghurtDribble" Inherits="Water">
         <part Name="LiquidVolume" MaxVolume="-1" Volume="10" StartVolume="1" InitialLiquid="yoghurt-1000"></part>

--- a/ObjectBlueprints.xml
+++ b/ObjectBlueprints.xml
@@ -10,7 +10,7 @@
                 <part Name="Render" DisplayName="milk glands" ColorString="&amp;M" RenderString="]" DetailColor="Y" Tile="items/udder.png" />
                 <part Name="LiquidProducer" Liquid="milk" Rate="1000" WorksOnWearer="true" WorksOnSelf="false" />
                 <part Name="Description" Short="Glands slowly secreting milk over time." />
-                <part Name="LiquidVolume"  MaxVolume="8" StartVolume="1-8" InitialLiquid="milk-1000" />
+                <part Name="LiquidVolume" MaxVolume="8" InitialLiquid="milk-1000" />
                 <part Name="Cursed" />
                 <part Name="NoDamage" />
                 <part Name="NoBreak" />

--- a/Qudders.csproj
+++ b/Qudders.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+    <ItemGroup>
+     <Reference Include="Assembly-CSharp">
+       <HintPath>~/.steam/steam/steamapps/common/Caves\ of\ Qud/CoQ_Data/Managed/Assembly-CSharp.dll</HintPath>
+     </Reference>
+    </ItemGroup>
+
+</Project>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# qudders
+# Qudders
+
+## Developing
+
+The following steps are optional but useful:
+
+- Install the `dotnet` command.
+- Copy or symbolic link `Assembly-CSharp.dll` and `UnityEngine.CoreModule.dll` from your *Caves of Qud* installation into this mod's directory. (These are ignored by this project's git settings.)
+
+Now you can `dotnet build` to error check the code and also use Visual Studio Code's code completion.

--- a/YoghurtLiquid.cs
+++ b/YoghurtLiquid.cs
@@ -75,7 +75,7 @@ namespace XRL.Liquids
 			return true;
 		}
 
-		public override void RenderBackground(LiquidVolume Liquid, RenderEvent eRender)
+		public override void RenderBackgroundPrimary(LiquidVolume Liquid, RenderEvent eRender)
 		{
 			eRender.ColorString = "^Y" + eRender.ColorString;
 		}
@@ -126,18 +126,14 @@ namespace XRL.Liquids
 			eRender.ColorString += "&Y";
 		}
 
-		public override void RenderSmearPrimary(LiquidVolume Liquid, RenderEvent eRender)
+		public override void RenderSmearPrimary(LiquidVolume Liquid, RenderEvent eRender, GameObject obj)
 		{
 			int num = XRLCore.CurrentFrame % 60;
 			if (num > 5 && num < 15)
 			{
 				eRender.ColorString = "&Y";
 			}
-			base.RenderSmearPrimary(Liquid, eRender);
-		}
-
-		public override void ObjectEnteredCell(LiquidVolume Liquid, GameObject GO)
-		{
+			base.RenderSmearPrimary(Liquid, eRender, obj);
 		}
 
 		public override float GetValuePerDram()

--- a/liquidpopulationhotloader.cs
+++ b/liquidpopulationhotloader.cs
@@ -1,7 +1,6 @@
 using System;
 using XRL.Rules;
 using Qud.API;
-using XRL.Rules;
 
 namespace XRL.World.Parts
 {


### PR DESCRIPTION
Based on #4; DNM until that is merged.
The Milk Glands mutation can now be leveled.
Production is 10% faster with each level, multiplicative.
Max volume increases by 2 with each level, starting at 8 at level 1.
Start volume now properly scales with starting mutation level; if you start with level 3 udders, they will start with between 1 and 12 drams of milk.
(Exact numbers are subject to change; this is the first implementation.)